### PR TITLE
EMP-95: Update gradle build action version to 2.12.0 (was 2.0.0)

### DIFF
--- a/.github/actions/build-app-gradle/action.yml
+++ b/.github/actions/build-app-gradle/action.yml
@@ -22,12 +22,12 @@ runs:
         distribution: ${{inputs.java-dist}}
 
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/gradle-build-action@v2.12.0
       with:
         build-root-directory: ${{inputs.working-directory}}
 
     - name: Build and install dependencies
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/gradle-build-action@v2.12.0
       with:
         arguments: |
           clean


### PR DESCRIPTION
EMP-95: Update gradle build action version to 2.12.0 (was 2.0.0)

## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
