### PR TITLE
EMP-329: Adding profileAcceptedTypes to CRM7 details endpoint

### DIFF
--- a/data-api/open-api-specification.yml
+++ b/data-api/open-api-specification.yml
@@ -72,6 +72,7 @@ paths:
         - CRM7Interface
       operationId: getApplicationCrm7
       parameters:
+        - $ref: '#/components/parameters/profileAcceptedTypes'
         - $ref: '#/components/parameters/crmUsn'
       responses:
         '200':

--- a/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/controller/Crm7Controller.java
+++ b/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/controller/Crm7Controller.java
@@ -21,10 +21,10 @@ public class Crm7Controller implements Crm7InterfaceApi {
     private final Crm7Mapper mapper;
 
     @Override
-    public ResponseEntity<Crm7DetailsDTO> getApplicationCrm7(Long usn) {
+    public ResponseEntity<Crm7DetailsDTO> getApplicationCrm7(Long usn, String profileAcceptedTypes) {
         log.info("eForm CRM7 details request received :: usn=[{}]", usn);
         CrmFormDetailsCriteriaDTO crmFormDetailsCriteriaDTO = new CrmFormDetailsCriteriaDTO(
-            usn, CRM_TYPE_7, null
+                usn, CRM_TYPE_7, null
         );
         Crm7DetailsModel crm7FileDetails = (Crm7DetailsModel) crmFileService.getCrmImageFile(crmFormDetailsCriteriaDTO).getFormDetails();
 

--- a/equinity-historical-data/src/test/java/uk/gov/justice/laa/crime/equinity/historicaldata/controller/Crm7ControllerTest.java
+++ b/equinity-historical-data/src/test/java/uk/gov/justice/laa/crime/equinity/historicaldata/controller/Crm7ControllerTest.java
@@ -34,6 +34,8 @@ import static uk.gov.justice.laa.crime.equinity.historicaldata.service.CrmFileSe
 @ExtendWith(SoftAssertionsExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class Crm7ControllerTest {
+    private static final String ACCEPTED_TYPES_DEFAULT = null;
+
     @InjectSoftAssertions
     private SoftAssertions softly;
 
@@ -79,7 +81,7 @@ class Crm7ControllerTest {
         String expectedMessage = "not be null";
 
         // execute
-        softly.assertThatThrownBy(() -> controller.getApplicationCrm7(null))
+        softly.assertThatThrownBy(() -> controller.getApplicationCrm7(null, ACCEPTED_TYPES_DEFAULT))
             .isInstanceOf(InvalidDataAccessApiUsageException.class)
             .hasMessageContaining(expectedMessage);
     }
@@ -87,7 +89,7 @@ class Crm7ControllerTest {
     @Test
     void getApplicationCrm7Test_WhenGivenNonExistingUsnThenReturnTaskNotFoundException() {
         Long usnTest = 10L;
-        softly.assertThatThrownBy(() -> controller.getApplicationCrm7(usnTest))
+        softly.assertThatThrownBy(() -> controller.getApplicationCrm7(usnTest, ACCEPTED_TYPES_DEFAULT))
             .isInstanceOf(ResourceNotFoundException.class)
             .hasMessageContaining("Task with USN").hasMessageContaining("not found");
     }
@@ -98,7 +100,7 @@ class Crm7ControllerTest {
         String expectedClientSurname = "Bond";
 
         validUsnTests.keySet().forEach((usnToTest) -> {
-            ResponseEntity<Crm7DetailsDTO> result = controller.getApplicationCrm7(usnToTest);
+            ResponseEntity<Crm7DetailsDTO> result = controller.getApplicationCrm7(usnToTest, ACCEPTED_TYPES_DEFAULT);
 
             softly.assertThat(result.getBody()).isNotNull();
             softly.assertThat(result.getBody()).isInstanceOf(Crm7DetailsDTO.class);


### PR DESCRIPTION
EMP-329: Adding profileAcceptedTypes to CRM7 details endpoint. Note: this will only affect the API contract, no logic added at the moment

## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
