### PR TITLE
EMP-329: Adding profileAcceptedTypes to CRM4 and CRM5 details endpoint

### DIFF
--- a/data-api/open-api-specification.yml
+++ b/data-api/open-api-specification.yml
@@ -57,6 +57,7 @@ paths:
         - CRM4Interface
       operationId: getApplicationCrm4
       parameters:
+        - $ref: '#/components/parameters/profileAcceptedTypes'
         - $ref: '#/components/parameters/crmUsn'
       responses:
         '200':

--- a/data-api/open-api-specification.yml
+++ b/data-api/open-api-specification.yml
@@ -42,6 +42,7 @@ paths:
         - CRM5Interface
       operationId: getApplication
       parameters:
+        - $ref: '#/components/parameters/profileAcceptedTypes'
         - $ref: '#/components/parameters/crmUsn'
       responses:
         '200':

--- a/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/controller/Crm4Controller.java
+++ b/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/controller/Crm4Controller.java
@@ -22,7 +22,7 @@ public class Crm4Controller implements Crm4InterfaceApi {
     private final Crm4Mapper crm4Mapper;
 
     @Override
-    public ResponseEntity<Crm4DetailsDTO> getApplicationCrm4(Long usn) {
+    public ResponseEntity<Crm4DetailsDTO> getApplicationCrm4(Long usn, String profileAcceptedTypes) {
         log.info("eForm CRM4 details request received :: usn=[{}]", usn);
         CrmFormDetailsCriteriaDTO crmFormDetailsCriteriaDTO = new CrmFormDetailsCriteriaDTO(
                 usn, CRM_TYPE_4, null

--- a/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/controller/Crm5Controller.java
+++ b/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/controller/Crm5Controller.java
@@ -20,8 +20,9 @@ public class Crm5Controller implements Crm5InterfaceApi {
     private final CrmFileService crmFileService;
     private final Crm5Mapper crm5Mapper;
 
+
     @Override
-    public ResponseEntity<CRM5DetailsDTO> getApplication(Long usn) {
+    public ResponseEntity<CRM5DetailsDTO> getApplication(Long usn, String profileAcceptedTypes) {
         log.info("eForm CRM5 details request received :: usn=[{}]", usn);
         CrmFormDetailsCriteriaDTO crmFormDetailsCriteriaDTO = new CrmFormDetailsCriteriaDTO(
                 usn, CRM_TYPE_5, null

--- a/equinity-historical-data/src/test/java/uk/gov/justice/laa/crime/equinity/historicaldata/controller/Crm4ControllerTest.java
+++ b/equinity-historical-data/src/test/java/uk/gov/justice/laa/crime/equinity/historicaldata/controller/Crm4ControllerTest.java
@@ -31,6 +31,8 @@ import static uk.gov.justice.laa.crime.equinity.historicaldata.service.CrmFileSe
 @ExtendWith(SoftAssertionsExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class Crm4ControllerTest {
+    private static final String ACCEPTED_TYPES_DEFAULT = null;
+
     @InjectSoftAssertions
     private SoftAssertions softly;
 
@@ -61,7 +63,7 @@ class Crm4ControllerTest {
         String expectedMessage = "not be null";
 
         // execute
-        softly.assertThatThrownBy(() -> controller.getApplicationCrm4(null))
+        softly.assertThatThrownBy(() -> controller.getApplicationCrm4(null, ACCEPTED_TYPES_DEFAULT))
             .isInstanceOf(InvalidDataAccessApiUsageException.class)
             .hasMessageContaining(expectedMessage);
     }
@@ -69,7 +71,7 @@ class Crm4ControllerTest {
     @Test
     void getApplicationCrm4Test_WhenGivenNonExistingUsnThenReturnTaskNotFoundException() {
         Long usnTest = 10L;
-        softly.assertThatThrownBy(() -> controller.getApplicationCrm4(usnTest))
+        softly.assertThatThrownBy(() -> controller.getApplicationCrm4(usnTest, ACCEPTED_TYPES_DEFAULT))
             .isInstanceOf(ResourceNotFoundException.class)
             .hasMessageContaining("Task with USN").hasMessageContaining("not found");
     }
@@ -78,7 +80,7 @@ class Crm4ControllerTest {
     void getApplicationCrm4Test_WhenGivenExistingUsnThenReturnValidResponse() {
         Long usnTest = 5001912L;
         String urn = "GH65789";
-        ResponseEntity<Crm4DetailsDTO> result = controller.getApplicationCrm4(usnTest);
+        ResponseEntity<Crm4DetailsDTO> result = controller.getApplicationCrm4(usnTest, ACCEPTED_TYPES_DEFAULT);
 
         softly.assertThat(result.getBody()).isNotNull();
         softly.assertThat(result.getBody()).isInstanceOf(Crm4DetailsDTO.class);

--- a/equinity-historical-data/src/test/java/uk/gov/justice/laa/crime/equinity/historicaldata/controller/Crm5ControllerTest.java
+++ b/equinity-historical-data/src/test/java/uk/gov/justice/laa/crime/equinity/historicaldata/controller/Crm5ControllerTest.java
@@ -22,7 +22,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
-import static uk.gov.justice.laa.crime.equinity.historicaldata.service.CrmFileService.CRM_TYPE_4;
 import static uk.gov.justice.laa.crime.equinity.historicaldata.service.CrmFileService.CRM_TYPE_5;
 
 
@@ -30,6 +29,7 @@ import static uk.gov.justice.laa.crime.equinity.historicaldata.service.CrmFileSe
 @ExtendWith(SoftAssertionsExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class Crm5ControllerTest {
+    private static final String ACCEPTED_TYPES_DEFAULT = null;
 
     @Autowired
     TaskImageFilesRepository taskImageFilesRepository;
@@ -43,7 +43,7 @@ public class Crm5ControllerTest {
     @Test
     void getApplication_TaskNotFound() {
         Long usnTest = 10L;
-        softly.assertThatThrownBy(() -> controller.getApplication(usnTest))
+        softly.assertThatThrownBy(() -> controller.getApplication(usnTest, ACCEPTED_TYPES_DEFAULT))
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessageContaining("Task with USN").hasMessageContaining("not found");
 
@@ -52,7 +52,7 @@ public class Crm5ControllerTest {
     @Test
     void getApplication_Valid() {
         Long usnTest = 5001604L;
-        ResponseEntity<CRM5DetailsDTO> result = controller.getApplication(usnTest);
+        ResponseEntity<CRM5DetailsDTO> result = controller.getApplication(usnTest, ACCEPTED_TYPES_DEFAULT);
         softly.assertThat(result.getBody()).isInstanceOf(CRM5DetailsDTO.class);
         softly.assertThat(result.getBody().getUsn()).isEqualTo(5001604);
         softly.assertThat(result.getBody().getFirm().getFirmName()).isEqualTo("MOCK_FIRM_001");


### PR DESCRIPTION
EMP-329: Adding profileAcceptedTypes to CRM4 and CRM5 details endpoint. Note: this will only affect the API contract, no logic added at the moment

## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
