### PR TITLE
EMP-329: Enabling logic to check for profileAcceptedTypes from controllers and updated unit tests for coverage

### DIFF
--- a/equinity-historical-data/build.gradle
+++ b/equinity-historical-data/build.gradle
@@ -6,7 +6,7 @@ plugins {
 def versions = [
 		springdocVersion       		: '1.8.0',
 		springStarter		  		: '3.2.5',
-		springWeb					: '6.1.6',
+		springWeb					: '6.2.4',
 		springSecurity		  	 	: '6.2.4',
 		logback						: '1.5.6',
 ]

--- a/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/controller/Crm4Controller.java
+++ b/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/controller/Crm4Controller.java
@@ -25,7 +25,7 @@ public class Crm4Controller implements Crm4InterfaceApi {
     public ResponseEntity<Crm4DetailsDTO> getApplicationCrm4(Long usn, String profileAcceptedTypes) {
         log.info("eForm CRM4 details request received :: usn=[{}]", usn);
         CrmFormDetailsCriteriaDTO crmFormDetailsCriteriaDTO = new CrmFormDetailsCriteriaDTO(
-                usn, CRM_TYPE_4, null
+                usn, CRM_TYPE_4, profileAcceptedTypes
         );
         Crm4DetailsModel crm4FileDetails = (Crm4DetailsModel) crmFileService
                 .getCrmImageFile(crmFormDetailsCriteriaDTO)

--- a/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/controller/Crm5Controller.java
+++ b/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/controller/Crm5Controller.java
@@ -25,7 +25,7 @@ public class Crm5Controller implements Crm5InterfaceApi {
     public ResponseEntity<CRM5DetailsDTO> getApplication(Long usn, String profileAcceptedTypes) {
         log.info("eForm CRM5 details request received :: usn=[{}]", usn);
         CrmFormDetailsCriteriaDTO crmFormDetailsCriteriaDTO = new CrmFormDetailsCriteriaDTO(
-                usn, CRM_TYPE_5, null
+                usn, CRM_TYPE_5, profileAcceptedTypes
         );
         Crm5DetailsModel crm5FileDetails = (Crm5DetailsModel) crmFileService
                 .getCrmImageFile(crmFormDetailsCriteriaDTO)

--- a/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/controller/Crm7Controller.java
+++ b/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/controller/Crm7Controller.java
@@ -24,7 +24,7 @@ public class Crm7Controller implements Crm7InterfaceApi {
     public ResponseEntity<Crm7DetailsDTO> getApplicationCrm7(Long usn, String profileAcceptedTypes) {
         log.info("eForm CRM7 details request received :: usn=[{}]", usn);
         CrmFormDetailsCriteriaDTO crmFormDetailsCriteriaDTO = new CrmFormDetailsCriteriaDTO(
-                usn, CRM_TYPE_7, null
+                usn, CRM_TYPE_7, profileAcceptedTypes
         );
         Crm7DetailsModel crm7FileDetails = (Crm7DetailsModel) crmFileService.getCrmImageFile(crmFormDetailsCriteriaDTO).getFormDetails();
 

--- a/equinity-historical-data/src/test/java/uk/gov/justice/laa/crime/equinity/historicaldata/controller/Crm4ControllerTest.java
+++ b/equinity-historical-data/src/test/java/uk/gov/justice/laa/crime/equinity/historicaldata/controller/Crm4ControllerTest.java
@@ -31,7 +31,8 @@ import static uk.gov.justice.laa.crime.equinity.historicaldata.service.CrmFileSe
 @ExtendWith(SoftAssertionsExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class Crm4ControllerTest {
-    private static final String ACCEPTED_TYPES_DEFAULT = null;
+    private static final String ACCEPTED_PROFILE_TYPES = Integer.toString(CRM_TYPE_4);
+    private static final String DENIED_PROFILE_TYPES = "9,19";
 
     @InjectSoftAssertions
     private SoftAssertions softly;
@@ -63,7 +64,7 @@ class Crm4ControllerTest {
         String expectedMessage = "not be null";
 
         // execute
-        softly.assertThatThrownBy(() -> controller.getApplicationCrm4(null, ACCEPTED_TYPES_DEFAULT))
+        softly.assertThatThrownBy(() -> controller.getApplicationCrm4(null, ACCEPTED_PROFILE_TYPES))
             .isInstanceOf(InvalidDataAccessApiUsageException.class)
             .hasMessageContaining(expectedMessage);
     }
@@ -71,7 +72,7 @@ class Crm4ControllerTest {
     @Test
     void getApplicationCrm4Test_WhenGivenNonExistingUsnThenReturnTaskNotFoundException() {
         Long usnTest = 10L;
-        softly.assertThatThrownBy(() -> controller.getApplicationCrm4(usnTest, ACCEPTED_TYPES_DEFAULT))
+        softly.assertThatThrownBy(() -> controller.getApplicationCrm4(usnTest, ACCEPTED_PROFILE_TYPES))
             .isInstanceOf(ResourceNotFoundException.class)
             .hasMessageContaining("Task with USN").hasMessageContaining("not found");
     }
@@ -80,12 +81,37 @@ class Crm4ControllerTest {
     void getApplicationCrm4Test_WhenGivenExistingUsnThenReturnValidResponse() {
         Long usnTest = 5001912L;
         String urn = "GH65789";
-        ResponseEntity<Crm4DetailsDTO> result = controller.getApplicationCrm4(usnTest, ACCEPTED_TYPES_DEFAULT);
+        ResponseEntity<Crm4DetailsDTO> result;
+
+        // Test with Accepted profile
+        result = controller.getApplicationCrm4(usnTest, ACCEPTED_PROFILE_TYPES);
 
         softly.assertThat(result.getBody()).isNotNull();
         softly.assertThat(result.getBody()).isInstanceOf(Crm4DetailsDTO.class);
         softly.assertThat(Objects.requireNonNull(result.getBody()).getCaseDetails().getFirm().getUrn()).isEqualTo(urn);
         softly.assertThat(Objects.requireNonNull(result.getBody()).getExpenditureDetails().getDetails()).isNotNull();
         softly.assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void getApplicationCrm4Test_WhenGivenExistingUsnWithNoProfileAcceptedTypesThenReturnValidResponse() {
+        Long usnTest = 5001912L;
+        String urn = "GH65789";
+        ResponseEntity<Crm4DetailsDTO> result = controller.getApplicationCrm4(usnTest, null);
+
+        softly.assertThat(result.getBody()).isNotNull();
+        softly.assertThat(result.getBody()).isInstanceOf(Crm4DetailsDTO.class);
+        softly.assertThat(Objects.requireNonNull(result.getBody()).getCaseDetails().getFirm().getUrn()).isEqualTo(urn);
+        softly.assertThat(Objects.requireNonNull(result.getBody()).getExpenditureDetails().getDetails()).isNotNull();
+        softly.assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void getApplicationCrm4Test_WhenGivenExistingUsnButNotAcceptedTypeThenReturnTaskNotFoundException() {
+        Long usnTest = 5001912L;
+
+        softly.assertThatThrownBy(() -> controller.getApplicationCrm4(usnTest, DENIED_PROFILE_TYPES))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Task with USN").hasMessageContaining("not found");
     }
 }


### PR DESCRIPTION
EMP-329: Enabling logic to check for profileAcceptedTypes from controllers and updated unit tests for coverage

EMP-329: Enabling logic to check for profileAcceptedTypes from controllers and updated unit tests for coverage

## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
