### PR TITLE
EMP-389 - Adding CRM14 Missing Fields

### DIFF
--- a/data-api/schemas/crm14.yml
+++ b/data-api/schemas/crm14.yml
@@ -193,6 +193,8 @@ Crm14APartnerDetailsDTO:
       $ref: "#/Crm14AboutYouDTO"
     homeAddress:
       $ref: "#/Crm14AddressDetailsDTO"
+    witnessTrace:
+      type: string
     coDefendant:
       type: string
     conflictOfInterest:

--- a/data-api/schemas/crm14.yml
+++ b/data-api/schemas/crm14.yml
@@ -68,6 +68,10 @@ Crm14LegalRepUseDTO:
       type: integer
     urn:
       type: string
+    prevAppUsn:
+      type: integer
+    prevAppMaat:
+      type: integer
     applicationType:
       type: string
     meansTested:

--- a/data-api/schemas/crm14.yml
+++ b/data-api/schemas/crm14.yml
@@ -96,6 +96,9 @@ Crm14LegalRepUseDTO:
     dateOfTrial:
       type: string
       format: date-time
+    appealLodgedDate:
+      type: string
+      format: date-time
 
 Crm14AboutYouPart1DTO:
   type: object
@@ -169,10 +172,15 @@ Crm14AboutYouPart2DTO:
       type: string
     under18:
       type: string
+    chargedWithAdult:
+        type: string
     havePartner:
       type: integer
     maritalStatus:
       type: string
+    dateOfSeparation:
+      type: string
+      format: date-time
 
 Crm14APartnerDetailsDTO:
   type: object

--- a/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/mapper/Crm14Mapper.java
+++ b/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/mapper/Crm14Mapper.java
@@ -36,8 +36,11 @@ public interface Crm14Mapper extends CrmMapper {
     @Mapping(target = "privacyAgree", source = "privacy_agree")
     @Mapping(target = "submit", source = "last_action")
     Crm14DetailsDTO getDTODetailsFromModel(Crm14DetailsModel model);
+
     @Mapping(target="usn", source="usn")
     @Mapping(target="urn", source="urn")
+    @Mapping(target="prevAppUsn", source="prev_app_usn")
+    @Mapping(target="prevAppMaat", source="prev_app_maat")
     @Mapping(target="applicationType", source="application_type")
     @Mapping(target="meansTested", source="means_tested")
     @Mapping(target="caseType", expression="java(convertCaseType(model))")

--- a/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/mapper/Crm14Mapper.java
+++ b/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/mapper/Crm14Mapper.java
@@ -50,6 +50,7 @@ public interface Crm14Mapper extends CrmMapper {
     @Mapping(target="priorityCaseType.lateApplication", source="late_application_cc")
     @Mapping(target="priorityCaseType.imminentHearing", source="hearing_date_imminent")
     @Mapping(target="dateOfTrial", source="date_of_trial")
+    @Mapping(target="appealLodgedDate", source="appeal_lodged_date")
     Crm14LegalRepUseDTO getLegalUseRepDTOFromModel(Crm14DetailsModel model);
 
     @Mapping(target="title", source="title")
@@ -85,6 +86,7 @@ public interface Crm14Mapper extends CrmMapper {
     @Mapping(target = "chargedWithAdult", source = "charged_with_adult")
     @Mapping(target = "havePartner", source = "have_partner")
     @Mapping(target = "maritalStatus", source="marital_status_2")
+    @Mapping(target = "dateOfSeparation", source = "date_of_separation")
     Crm14AboutYouPart2DTO getAboutYouPart2DTOFromModel(Crm14DetailsModel model);
     @Mapping(target = "applicantFullName", source="user_signed_name")
     @Mapping(target = "applicantSignedDate", source="user_signed_date")

--- a/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/mapper/Crm14Mapper.java
+++ b/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/mapper/Crm14Mapper.java
@@ -156,6 +156,7 @@ public interface Crm14Mapper extends CrmMapper {
     @Mapping(target="homeAddress.addressLine2", source = "partner_usual_address_2")
     @Mapping(target="homeAddress.addressLine3", source = "partner_usual_address_3")
     @Mapping(target="homeAddress.postCode", source = "partner_usual_postcode")
+    @Mapping(target="witnessTrace", source = "witness_trace")
     @Mapping(target="coDefendant", source = "any_codefendants")
     @Mapping(target="partnerDifferentHome", source = "partner_different_home")
     @Mapping(target="conflictOfInterest", source = "partner_conflict_of_interest")

--- a/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/mapper/Crm14Mapper.java
+++ b/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/mapper/Crm14Mapper.java
@@ -82,6 +82,7 @@ public interface Crm14Mapper extends CrmMapper {
     @Mapping(target = "homeAddressType", source = "home_address_type")
     @Mapping(target = "relationshipToHomeOwner", source = "relationship_to_home_owner")
     @Mapping(target = "under18", source = "under_18")
+    @Mapping(target = "chargedWithAdult", source = "charged_with_adult")
     @Mapping(target = "havePartner", source = "have_partner")
     @Mapping(target = "maritalStatus", source="marital_status_2")
     Crm14AboutYouPart2DTO getAboutYouPart2DTOFromModel(Crm14DetailsModel model);

--- a/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/model/Crm14DetailsModel.java
+++ b/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/model/Crm14DetailsModel.java
@@ -31,6 +31,8 @@ public class Crm14DetailsModel extends Crm14AdditionalDetails implements CrmForm
     public String why_not_rep_same_solicitor_reasons;
     @JsonProperty("Under_18")
     public String under_18;
+    @JsonProperty("Charged_with_adult")
+    public String charged_with_adult;
     @JsonProperty("Proceedings_already_concluded")
     public String proceedings_already_concluded;
     @JsonProperty("Fc_eligible_for_assessment_result_inject")
@@ -73,8 +75,6 @@ public class Crm14DetailsModel extends Crm14AdditionalDetails implements CrmForm
     public boolean witness_trace;
     @JsonProperty("Tlautonumber")
     public int tlautonumber;
-    @JsonProperty("Charged_with_adult")
-    public String charged_with_adult;
     @JsonProperty("Dwp_check_result")
     public String dwp_check_result;
     @JsonProperty("Legal_rep_declaration")

--- a/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/model/Crm14DetailsModel.java
+++ b/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/model/Crm14DetailsModel.java
@@ -33,6 +33,8 @@ public class Crm14DetailsModel extends Crm14AdditionalDetails implements CrmForm
     public String under_18;
     @JsonProperty("Charged_with_adult")
     public String charged_with_adult;
+    @JsonProperty("Date_of_separation")
+    public String date_of_separation;
     @JsonProperty("Proceedings_already_concluded")
     public String proceedings_already_concluded;
     @JsonProperty("Fc_eligible_for_assessment_result_inject")
@@ -371,6 +373,8 @@ public class Crm14DetailsModel extends Crm14AdditionalDetails implements CrmForm
     public int priority_case_calc;
     @JsonProperty("Date_of_trial")
     public Date date_of_trial;
+    @JsonProperty("Appeal_lodged_date")
+    public Date appeal_lodged_date;
     @JsonProperty("Has_errors")
     public boolean has_errors;
     @JsonProperty("Ni_number")

--- a/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/model/Crm14DetailsModel.java
+++ b/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/model/Crm14DetailsModel.java
@@ -331,6 +331,8 @@ public class Crm14DetailsModel extends Crm14AdditionalDetails implements CrmForm
     public int land_calc_2;
     @JsonProperty("Originator_jobtitle")
     public String originator_jobtitle;
+    @JsonProperty("Prev_app_usn")
+    public String prev_app_usn;
     @JsonProperty("Prev_app_maat")
     public String prev_app_maat;
     @JsonProperty("Legal_rep_declaration_2")


### PR DESCRIPTION
# # Following missing fields are fixed

> USN & Matt_ID
> Appeal Lodged Date
> Are you charged with an adult?
> Date of separation
> Please specify

The following fields will be fixed in the next pull request - We are waiting for the inputs from BA
> You are and your partner are - Can't find it in the sheet

> You are - Martial status: returns empty string for few URNS
    ```
   5001541 - Empty string
    5001524 - prefer no to say
   5001539 - Married or Cohabiting
```