### PR TITLE
EMP-182: Reverted prometheus dependency version back to 1.12

### DIFF
--- a/equinity-historical-data/build.gradle
+++ b/equinity-historical-data/build.gradle
@@ -14,7 +14,7 @@ def versions = [
 		openAPI						: '2.6.0',
 		sentryVersion				: '7.13.0',
 		micrometerio 				: '1.3.2',
-		prometheus 					: '1.13.2',
+		prometheus 					: '1.12.6',
 ]
 
 configurations {

--- a/equinity-historical-data/src/main/resources/application.yaml
+++ b/equinity-historical-data/src/main/resources/application.yaml
@@ -23,14 +23,12 @@ spring:
 springdoc:
   packagesToScan: uk.gov.justice.laa.crime.equinity.historicaldata
   show-actuator: true
-  use-management-port: true
   api-docs:
     path: /api-docs
     enabled: false
   swagger-ui:
     path: /swagger-ui
     enabled: false
-    operationsSorter: method
 
 datasource:
   archive:


### PR DESCRIPTION
EMP-182: Reverted prometheus dependency version back to 1.12. It seems versions 1.13+ need other updates that we could handled as a separate ticket later.

## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
