### PR TITLE
EMP-650: Added isProcessed attribute for downloadable CRM14 evidence flles coming from processed section

### DIFF
--- a/data-api/schemas/crmEvidenceFiles.yml
+++ b/data-api/schemas/crmEvidenceFiles.yml
@@ -16,3 +16,5 @@ CrmEvidenceFileDTO:
         string
     name:
       type: string
+    isProcessed:
+      type: boolean

--- a/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/mapper/Crm14Mapper.java
+++ b/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/mapper/Crm14Mapper.java
@@ -12,7 +12,7 @@ import uk.gov.justice.laa.crime.equinity.historicaldata.model.data.CrmFormCRM14P
 import uk.gov.justice.laa.crime.equinity.historicaldata.util.Crm14CaseTypeUtil;
 
 @Mapper(componentModel = "spring")
-public interface Crm14Mapper extends CrmMapper {
+public interface Crm14Mapper extends CrmEvidenceFilesMapper {
     String PARTNER_INVOLVED_OPT1 = "Co-defendant";
     String PARTNER_INVOLVED_OPT2 = "Prosecution witness";
     String PARTNER_INVOLVED_OPT3 = "Victim";

--- a/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/mapper/Crm5Mapper.java
+++ b/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/mapper/Crm5Mapper.java
@@ -7,7 +7,7 @@ import uk.gov.justice.laa.crime.equinity.historicaldata.model.crm5.Crm5DetailsMo
 import uk.gov.justice.laa.crime.equinity.historicaldata.model.crm5.Crm5Model;
 
 @Mapper(componentModel = "spring")
-public interface Crm5Mapper extends CrmMapper {
+public interface Crm5Mapper extends CrmEvidenceFilesMapper {
     @Mapping(target="formDetails", source="formDetails")
     @Mapping(target="evidenceFiles", source="evidenceFiles")
     Crm5FormDTO getDTOFromModel(Crm5Model model);

--- a/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/mapper/Crm7Mapper.java
+++ b/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/mapper/Crm7Mapper.java
@@ -9,7 +9,7 @@ import uk.gov.justice.laa.crime.equinity.historicaldata.model.crm7.Crm7Model;
 import uk.gov.justice.laa.crime.equinity.historicaldata.model.crm7.Crm7TimeSpentModel;
 
 @Mapper(componentModel = "spring")
-public interface Crm7Mapper extends CrmMapper {
+public interface Crm7Mapper extends CrmEvidenceFilesMapper {
 
     @Mapping(target="formDetails", source="formDetails")
     @Mapping(target="evidenceFiles", source="evidenceFiles")

--- a/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/mapper/CrmEvidenceFilesMapper.java
+++ b/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/mapper/CrmEvidenceFilesMapper.java
@@ -15,5 +15,6 @@ public interface CrmEvidenceFilesMapper extends CrmMapper {
     @Mapping(target="key", source="key")
     @Mapping(target="type", source="type")
     @Mapping(target="name", source="name")
+    @Mapping(target="isProcessed", source="isProcessed")
     CrmEvidenceFileDTO getDTOFromModel(CrmEvidenceFileModel crmEvidenceFileModelModel);
 }

--- a/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/model/CrmEvidenceFileModel.java
+++ b/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/model/CrmEvidenceFileModel.java
@@ -15,4 +15,6 @@ public class CrmEvidenceFileModel {
     private String type;
     @JsonProperty("name")
     private String name;
+
+    private Boolean isProcessed;
 }

--- a/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/model/crm14/Crm14Model.java
+++ b/equinity-historical-data/src/main/java/uk/gov/justice/laa/crime/equinity/historicaldata/model/crm14/Crm14Model.java
@@ -26,13 +26,13 @@ public class Crm14Model implements CrmFormModelInterface {
     @JsonProperty("linkedAttachments")
     private CrmEvidenceFilesModel evidenceFiles;
 
-    // TODO (EMP-557): Should it be considered moving this function to class CrmEvidenceFilesModel ?
     public void addProcessedAttachmentsToEvidence(List<CrmFormCRM14AttachmentStoreModel> processedAttachments) {
         for(CrmFormCRM14AttachmentStoreModel processedAttachment: processedAttachments){
             CrmEvidenceFileModel evidenceFileModel = new CrmEvidenceFileModel();
             evidenceFileModel.setKey("att_"+processedAttachment.getAttachmentId()+".att");
             evidenceFileModel.setName(processedAttachment.getFileName());
             evidenceFileModel.setType(processedAttachment.getEvidenceType());
+            evidenceFileModel.setIsProcessed(true);
             getEvidenceFiles().getFiles().add(evidenceFileModel);
         }
     }


### PR DESCRIPTION
## What
EMP-650: Added isProcessed attribute for downloadable CRM14 evidence flles coming from processed section.  
EMP-650: Fix CRM4, CRM5 and CRM7 base mapper to CrmEvidenceFilesMapper, was CrmMapper.  

Link to story [EMP-650](https://dsdmoj.atlassian.net/browse/EMP-650)

Link to parent story [EMP-648](https://dsdmoj.atlassian.net/browse/EMP-648)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.


[EMP-650]: https://dsdmoj.atlassian.net/browse/EMP-650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMP-648]: https://dsdmoj.atlassian.net/browse/EMP-648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ