### PR TITLE
EMP-766: Fix archive deploy read-only error

### DIFF
--- a/data-api/build.gradle
+++ b/data-api/build.gradle
@@ -5,7 +5,7 @@ plugins {
 apply plugin: "maven-publish"
 
 def versions = [
-        springStarter               : '3.3.5',
+        springStarter               : '3.3.7',
         springWeb                   : '6.1.14',
         springData                  : '3.3.4',
         springdoc                   : '1.8.0',

--- a/equinity-historical-data/build.gradle
+++ b/equinity-historical-data/build.gradle
@@ -4,7 +4,7 @@ plugins {
 	id "io.sentry.jvm.gradle" version "4.10.0"
 }
 def versions = [
-		springStarter 				: '3.3.5',
+		springStarter 				: '3.3.7',
 		springWeb 					: '6.1.14',
 		springSecurity 				: '6.3.4',
 		springdoc 					: '1.8.0',

--- a/kubernetes/helm_deploy/laa-crime-equinity-historical-data/values-archive.yaml
+++ b/kubernetes/helm_deploy/laa-crime-equinity-historical-data/values-archive.yaml
@@ -13,6 +13,11 @@ service:
   port: 8089
   environment: "archive"
 
+securityContext:
+  runAsNonRoot: true
+  readOnlyRootFilesystem: false
+  runAsUser: 10001
+
 database:
   name: "eq_archive"
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/EMP-766)

Turned off the ready-only file system for the archive pod deployment in `values-archive.yaml`

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
